### PR TITLE
Update resource.rb

### DIFF
--- a/lib/vra/resource.rb
+++ b/lib/vra/resource.rb
@@ -165,24 +165,26 @@ module Vra
 
       resource_views = @client.http_get("/catalog-service/api/consumer/requests/#{request_id}/resourceViews")
 
-      data_zero = JSON.parse(resource_views.body)["content"][0]["data"]["ip_address"]
-      data_one = JSON.parse(resource_views.body)["content"][1]["data"]["ip_address"]
+      data_zero = JSON.parse(resource_views.body)["content"][0]["data"]["NETWORK_LIST"]
+      data_one = JSON.parse(resource_views.body)["content"][1]["data"]["NETWORK_LIST"]
 
       print "Waiting For vRA to collect the IP"
       while (data_zero == "" || data_one == "") && (data_zero.nil? || data_one.nil?)
         resource_views = @client.http_get("/catalog-service/api/consumer/requests/#{request_id}/resourceViews")
-        data_zero = JSON.parse(resource_views.body)["content"][0]["data"]["ip_address"]
-        data_one = JSON.parse(resource_views.body)["content"][1]["data"]["ip_address"]
+        data_zero = JSON.parse(resource_views.body)["content"][0]["data"]["NETWORK_LIST"]
+        data_one = JSON.parse(resource_views.body)["content"][1]["data"]["NETWORK_LIST"]
         sleep 10
         print "."
       end
 
-      ip_address = if JSON.parse(resource_views.body)["content"][0]["data"]["ip_address"].nil?
-                     JSON.parse(resource_views.body)["content"][1]["data"]["ip_address"]
+      ip_address = if JSON.parse(resource_views.body)["content"][0]["data"]["NETWORK_LIST"].nil?
+                     JSON.parse(resource_views.body)["content"][1]["data"]["NETWORK_LIST"][0]["data"]["NETWORK_ADDRESS"]
                    else
-                     JSON.parse(resource_views.body)["content"][0]["data"]["ip_address"]
+                     JSON.parse(resource_views.body)["content"][0]["data"]["NETWORK_LIST"][0]["data"]["NETWORK_ADDRESS"]
                    end
 
+      print "\n","Using IP address ",ip_address,"\n"
+    
       addrs << ip_address
       addrs
     end


### PR DESCRIPTION
### Description
Proposed changes to make use of the "static from time of request" IP address data returned from the resourceViews API call. 

### Issues Resolved
In some cases, such as when using a NSX Edge router between a public and private subnet, the previous ["content"][0]["data"]["ip_address"] data field occasionally gets updated by VMwareTools to the non-routable private IP address before the kitchen client is able to connect to the new VM, preventing the client from connecting and thus killing the build. Using the ["content"][0]["data"]["NETWORK_LIST"][0]["data"]["NETWORK_ADDRESS"] data field instead works every time, as this value seems to remain the static public IP address set at the time of build.

### Additional changes to make before merging
Instead of hard-coding this change, I would prefer to expose a .kitchen.yml config option to allow the end user choose between the two data fields so that they don't need a custom version of the vmware-vra gem installed to use the static IP address field.

### Testing
I have only tested this change with version 2.1.3 of the gem.